### PR TITLE
Add browser UI for labeling papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,3 +202,13 @@
     ]
   }
 }```
+
+## MVP Labeling UI
+
+This repository includes a minimal browser-based interface for labeling a small set of research papers.
+
+### Usage
+
+1. Open `index.html` in a web browser.
+2. For each paper, choose a label (bronze, silver, gold) and add a short summary and meaning.
+3. Click **Download Labels** to export your annotations as `labels.json`. The page stores your progress in browser local storage.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Paper Labeler</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Research Paper Labeler</h1>
+  <div id="paper-container"></div>
+  <button id="download">Download Labels</button>
+
+  <script src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,101 @@
+let papers = [];
+
+function savePaper(id) {
+  const label = document.querySelector(`input[name="label-${id}"]:checked`);
+  const summary = document.getElementById(`summary-${id}`).value;
+  const meaning = document.getElementById(`meaning-${id}`).value;
+  const data = {
+    label: label ? label.value : "",
+    summary,
+    meaning
+  };
+  localStorage.setItem(`paper-${id}`, JSON.stringify(data));
+}
+
+function loadSavedData(id) {
+  const raw = localStorage.getItem(`paper-${id}`);
+  if (!raw) return;
+  const data = JSON.parse(raw);
+  if (data.label) {
+    const radio = document.querySelector(`input[name="label-${id}"][value="${data.label}"]`);
+    if (radio) radio.checked = true;
+  }
+  document.getElementById(`summary-${id}`).value = data.summary || "";
+  document.getElementById(`meaning-${id}`).value = data.meaning || "";
+}
+
+function renderPaper(paper) {
+  const container = document.getElementById("paper-container");
+  const card = document.createElement("div");
+  card.className = "paper";
+
+  const title = document.createElement("h2");
+  title.textContent = paper.title;
+  card.appendChild(title);
+
+  const src = document.createElement("p");
+  src.className = "source";
+  src.textContent = paper.source;
+  card.appendChild(src);
+
+  const labelWrap = document.createElement("div");
+  ["bronze", "silver", "gold"].forEach(l => {
+    const label = document.createElement("label");
+    const radio = document.createElement("input");
+    radio.type = "radio";
+    radio.name = `label-${paper.id}`;
+    radio.value = l;
+    radio.addEventListener("change", () => savePaper(paper.id));
+    label.appendChild(radio);
+    label.append(` ${l}`);
+    labelWrap.appendChild(label);
+  });
+  card.appendChild(labelWrap);
+
+  const summary = document.createElement("textarea");
+  summary.id = `summary-${paper.id}`;
+  summary.placeholder = "Summary";
+  summary.addEventListener("input", () => savePaper(paper.id));
+  card.appendChild(summary);
+
+  const meaning = document.createElement("textarea");
+  meaning.id = `meaning-${paper.id}`;
+  meaning.placeholder = "Meaning";
+  meaning.addEventListener("input", () => savePaper(paper.id));
+  card.appendChild(meaning);
+
+  container.appendChild(card);
+  loadSavedData(paper.id);
+}
+
+async function loadPapers() {
+  const res = await fetch("papers.json");
+  papers = await res.json();
+  papers.forEach(renderPaper);
+}
+
+function downloadLabels() {
+  const results = papers.map(p => {
+    const saved = localStorage.getItem(`paper-${p.id}`);
+    const data = saved ? JSON.parse(saved) : {};
+    return {
+      id: p.id,
+      title: p.title,
+      source: p.source,
+      label: data.label || "",
+      summary: data.summary || "",
+      meaning: data.meaning || ""
+    };
+  });
+  const blob = new Blob([JSON.stringify(results, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "labels.json";
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+document.getElementById("download").addEventListener("click", downloadLabels);
+
+loadPapers();

--- a/papers.json
+++ b/papers.json
@@ -1,0 +1,12 @@
+[
+  {"id":1,"title":"Sample Paper 1","source":"Lorem ipsum dolor sit amet, consectetur adipiscing elit."},
+  {"id":2,"title":"Sample Paper 2","source":"Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."},
+  {"id":3,"title":"Sample Paper 3","source":"Ut enim ad minim veniam, quis nostrud exercitation ullamco."},
+  {"id":4,"title":"Sample Paper 4","source":"Duis aute irure dolor in reprehenderit in voluptate velit esse."},
+  {"id":5,"title":"Sample Paper 5","source":"Cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat."},
+  {"id":6,"title":"Sample Paper 6","source":"Sunt in culpa qui officia deserunt mollit anim id est laborum."},
+  {"id":7,"title":"Sample Paper 7","source":"Phasellus faucibus scelerisque eleifend donec pretium vulputate sapien."},
+  {"id":8,"title":"Sample Paper 8","source":"Amet consectetur adipiscing elit duis tristique sollicitudin nibh."},
+  {"id":9,"title":"Sample Paper 9","source":"Fringilla est ullamcorper eget nulla facilisi etiam dignissim diam."},
+  {"id":10,"title":"Sample Paper 10","source":"Suspendisse potenti. Praesent tempor vehicula tortor."}
+]

--- a/style.css
+++ b/style.css
@@ -1,0 +1,25 @@
+body {
+  font-family: sans-serif;
+  margin: 20px;
+}
+
+.paper {
+  border: 1px solid #ccc;
+  padding: 10px;
+  margin-bottom: 20px;
+}
+
+.source {
+  background: #f5f5f5;
+  padding: 5px;
+}
+
+label {
+  margin-right: 10px;
+}
+
+textarea {
+  width: 100%;
+  height: 60px;
+  margin-top: 5px;
+}


### PR DESCRIPTION
## Summary
- add sample data for ten papers
- implement static HTML/JS UI to label papers with bronze/silver/gold tiers and record summary and meaning
- include download button to export labels to JSON and document usage

## Testing
- `python -m json.tool papers.json`

------
https://chatgpt.com/codex/tasks/task_e_68c74c869ba8832286dd5930946ca67c